### PR TITLE
Create objects to execute in the main method CategoryRepository and C…

### DIFF
--- a/src/main/java/com/rcrr/springbib/SpringbibApplication.java
+++ b/src/main/java/com/rcrr/springbib/SpringbibApplication.java
@@ -1,13 +1,36 @@
 package com.rcrr.springbib;
 
+
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
-public class SpringbibApplication {
+import com.rcrr.springbib.domain.Category;
+import com.rcrr.springbib.repositories.CategoryRepository;
 
+@SpringBootApplication
+public class SpringbibApplication implements CommandLineRunner {
+
+	@Autowired
+	private CategoryRepository categoryRepository;
+	
 	public static void main(String[] args) {
 		SpringApplication.run(SpringbibApplication.class, args);
 	}
 
+	@Override
+	public void run(String... args) throws Exception {
+		
+		Category cat1 = new Category(null, "IT");
+		Category cat2 = new Category(null, "Office");
+		
+		
+		categoryRepository.saveAll(Arrays.asList(cat1, cat2));
+	}
+	
+	
 }


### PR DESCRIPTION
The records for execution testing purposes were being created directly in the H2 table manually. Now, however, they have been implemented in the main method with the help of CommandLineRunner to be generated when spring is executed. These created objects are following a previously planned UML object diagram.